### PR TITLE
allowHexadecimal reader option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /doc/doxyfile
 /dist/
 /.cache/
+/.vscode/
 
 # MSVC project files:
 *.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ project(jsoncpp
         # 2. ./include/json/version.h
         # 3. ./CMakeLists.txt
         # IMPORTANT: also update the PROJECT_SOVERSION!!
-        VERSION 1.9.5 # <major>[.<minor>[.<patch>[.<tweak>]]]
+        VERSION 1.10.0 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)
 
 message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -324,6 +324,8 @@ public:
    * - `"allowSpecialFloats": false or true`
    *   - If true, special float values (NaNs and infinities) are allowed and
    *     their values are lossfree restorable.
+   * - `"allowHexadecimal": false or true`
+   *   - If true, allow hexadecimal (eg 0xFFFF) to be used as unsigned integers.
    * - `"skipBom": false or true`
    *   - If true, if the input starts with the Unicode byte order mark (BOM),
    *     it is skipped.

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -875,6 +875,7 @@ public:
   bool failIfExtra_;
   bool rejectDupKeys_;
   bool allowSpecialFloats_;
+  bool allowHexadecimal_;
   bool skipBom_;
   size_t stackLimit_;
 }; // OurFeatures
@@ -914,6 +915,7 @@ private:
     tokenArrayEnd,
     tokenString,
     tokenNumber,
+    tokenHexadecimal,
     tokenTrue,
     tokenFalse,
     tokenNull,
@@ -952,11 +954,14 @@ private:
   bool readString();
   bool readStringSingleQuote();
   bool readNumber(bool checkInf);
+  bool readHexadecimal();
   bool readValue();
   bool readObject(Token& token);
   bool readArray(Token& token);
   bool decodeNumber(Token& token);
   bool decodeNumber(Token& token, Value& decoded);
+  bool decodeHexadecimal(Token& token);
+  bool decodeHexadecimal(Token& token, Value& decoded);
   bool decodeString(Token& token);
   bool decodeString(Token& token, String& decoded);
   bool decodeDouble(Token& token);
@@ -1191,6 +1196,12 @@ bool OurReader::readToken(Token& token) {
     ok = readComment();
     break;
   case '0':
+    if(match("x", 1)) {
+      token.type_ = tokenHexadecimal;
+      ok = features_.allowHexadecimal_;
+      readHexadecimal();
+      break;
+    }
   case '1':
   case '2':
   case '3':
@@ -1419,6 +1430,18 @@ bool OurReader::readNumber(bool checkInf) {
   }
   return true;
 }
+
+bool OurReader::readHexadecimal(void) {
+  Location p = current_;
+  char c = '0'; // stopgap for already consumed character
+  // integral part
+  while ((c >= '0' && c <= '9')
+    || (c >= 'a' && c <= 'f')
+    || (c >= 'A' && c <= 'F'))
+    c = (current_ = p) < end_ ? *p++ : '\0';
+  return true;
+}
+
 bool OurReader::readString() {
   Char c = 0;
   while (current_ != end_) {
@@ -1636,6 +1659,44 @@ bool OurReader::decodeNumber(Token& token, Value& decoded) {
     decoded = value;
   }
 
+  return true;
+}
+
+bool OurReader::decodeHexadecimal(Token& token) {
+  Value decoded;
+  if (!decodeHexadecimal(token, decoded))
+    return false;
+  currentValue().swapPayload(decoded);
+  currentValue().setOffsetStart(token.start_ - begin_);
+  currentValue().setOffsetLimit(token.end_ - begin_);
+  return true;
+}
+
+bool OurReader::decodeHexadecimal(Token& token, Value& decoded) {
+  Json::LargestUInt value = 0;
+  constexpr Json::LargestUInt top =
+    Json::LargestUInt(0xF) << (sizeof(top) * 8) - 4; 
+
+  Location current = token.start_;
+  while (current < token.end_) {
+    Char c = *current++;
+    static_assert('A' < 'a');
+    static_assert('0' < 'A');
+    if (c == 'x')
+      continue;
+    else if (c >= 'a')
+      c -= 'a' - 10;
+    else if (c >= 'A')
+      c -= 'A' - 10;
+    else if (c >= '0')
+      c -= '0';
+    else return addError(
+        "Contains non-hexadecimal digits.", token, current);
+    if (value & top) return addError(
+        "Number is too large for unsigned integer.", token, current);
+    value = value << 4 | static_cast<Value::UInt>(c);
+  }
+  decoded = value;
   return true;
 }
 
@@ -1908,6 +1969,7 @@ CharReader* CharReaderBuilder::newCharReader() const {
   features.failIfExtra_ = settings_["failIfExtra"].asBool();
   features.rejectDupKeys_ = settings_["rejectDupKeys"].asBool();
   features.allowSpecialFloats_ = settings_["allowSpecialFloats"].asBool();
+  features.allowHexadecimal_ = settings_["allowHexacecimal"].asBool();
   features.skipBom_ = settings_["skipBom"].asBool();
   return new OurCharReader(collectComments, features);
 }
@@ -1925,6 +1987,7 @@ bool CharReaderBuilder::validate(Json::Value* invalid) const {
       "failIfExtra",
       "rejectDupKeys",
       "allowSpecialFloats",
+      "allowHexacecimal",
       "skipBom",
   };
   for (auto si = settings_.begin(); si != settings_.end(); ++si) {

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1200,8 +1200,12 @@ bool OurReader::readToken(Token& token) {
       token.type_ = tokenHexadecimal;
       ok = features_.allowHexadecimal_;
       readHexadecimal();
-      break;
     }
+    else {
+      token.type_ = tokenNumber;
+      readNumber(false);
+    }
+    break;
   case '1':
   case '2':
   case '3':
@@ -1675,16 +1679,12 @@ bool OurReader::decodeHexadecimal(Token& token) {
 bool OurReader::decodeHexadecimal(Token& token, Value& decoded) {
   Json::LargestUInt value = 0;
   constexpr Json::LargestUInt top =
-    Json::LargestUInt(0xF) << (sizeof(top) * 8) - 4; 
+    Json::LargestUInt(0xF) << ((sizeof(top) * 8) - 4); 
 
-  Location current = token.start_;
+  Location current = token.start_ + 2;
   while (current < token.end_) {
     Char c = *current++;
-    static_assert('A' < 'a');
-    static_assert('0' < 'A');
-    if (c == 'x')
-      continue;
-    else if (c >= 'a')
+    if (c >= 'a')
       c -= 'a' - 10;
     else if (c >= 'A')
       c -= 'A' - 10;

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1083,6 +1083,9 @@ bool OurReader::readValue() {
   case tokenNumber:
     successful = decodeNumber(token);
     break;
+  case tokenHexadecimal:
+    successful = decodeHexadecimal(token);
+    break;
   case tokenString:
     successful = decodeString(token);
     break;
@@ -1969,7 +1972,7 @@ CharReader* CharReaderBuilder::newCharReader() const {
   features.failIfExtra_ = settings_["failIfExtra"].asBool();
   features.rejectDupKeys_ = settings_["rejectDupKeys"].asBool();
   features.allowSpecialFloats_ = settings_["allowSpecialFloats"].asBool();
-  features.allowHexadecimal_ = settings_["allowHexacecimal"].asBool();
+  features.allowHexadecimal_ = settings_["allowHexadecimal"].asBool();
   features.skipBom_ = settings_["skipBom"].asBool();
   return new OurCharReader(collectComments, features);
 }
@@ -1987,7 +1990,7 @@ bool CharReaderBuilder::validate(Json::Value* invalid) const {
       "failIfExtra",
       "rejectDupKeys",
       "allowSpecialFloats",
-      "allowHexacecimal",
+      "allowHexadecimal",
       "skipBom",
   };
   for (auto si = settings_.begin(); si != settings_.end(); ++si) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3577,6 +3577,8 @@ JSONTEST_FIXTURE_LOCAL(CharReaderAllowHexadecimal, disallowHex) {
 JSONTEST_FIXTURE_LOCAL(CharReaderAllowHexadecimal, hexObject) {
   Json::CharReaderBuilder b;
   b.settings_["allowHexadecimal"] = true;
+  Json::Value invalid;
+  JSONTEST_ASSERT(b.validate(&invalid)) << invalid;
   CharReaderPtr reader(b.newCharReader());
   {
     Json::Value root;
@@ -3622,7 +3624,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderAllowHexadecimal, hexNumbers) {
     const char* c0 = td.in.c_str();
     const char* c1 = c0 + td.in.size();
     bool ok = reader->parse(c0, c1, &root, &errs);
-    JSONTEST_ASSERT_EQUAL(td.ok, ok);
+    JSONTEST_ASSERT(td.ok == ok) << "in: " << td.in;
     if (td.ok)
     {
       JSONTEST_ASSERT_EQUAL(0u, errs.size());


### PR DESCRIPTION
Add `"allowHexadecimal"` option for `CharReaderBuilder`. Allows hex formatted as `0x[0-9a-zA-Z]{1-16}` to be parsed as uint64 (`{1-8}` on 32-bit).